### PR TITLE
Add About screen

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,5 +1,7 @@
 PODS:
   - Flutter (1.0.0)
+  - package_info (0.0.1):
+    - Flutter
   - shared_preferences (0.0.1):
     - Flutter
   - shared_preferences_macos (0.0.1):
@@ -9,6 +11,7 @@ PODS:
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
+  - package_info (from `.symlinks/plugins/package_info/ios`)
   - shared_preferences (from `.symlinks/plugins/shared_preferences/ios`)
   - shared_preferences_macos (from `.symlinks/plugins/shared_preferences_macos/ios`)
   - shared_preferences_web (from `.symlinks/plugins/shared_preferences_web/ios`)
@@ -16,6 +19,8 @@ DEPENDENCIES:
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
+  package_info:
+    :path: ".symlinks/plugins/package_info/ios"
   shared_preferences:
     :path: ".symlinks/plugins/shared_preferences/ios"
   shared_preferences_macos:
@@ -25,6 +30,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
+  package_info: 48b108e75b8802c2d5e126f208ef540561c98aef
   shared_preferences: 430726339841afefe5142b9c1f50cb6bd7793e01
   shared_preferences_macos: f3f29b71ccbb56bf40c9dd6396c9acf15e214087
   shared_preferences_web: 141cce0c3ed1a1c5bf2a0e44f52d31eeb66e5ea9

--- a/lib/presentation/productSelection/screens/AboutScreen.dart
+++ b/lib/presentation/productSelection/screens/AboutScreen.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:package_info/package_info.dart';
+
+class AboutScreen extends StatefulWidget {
+  static String id = 'AboutScreen';
+
+  AboutScreen({Key key}) : super(key: key);
+
+  @override
+  _AboutScreenState createState() => _AboutScreenState();
+}
+
+class _AboutScreenState extends State<AboutScreen> {
+  PackageInfo _packageInfo = PackageInfo(
+    appName: 'Unknown',
+    packageName: 'Unknown',
+    version: 'Unknown',
+    buildNumber: 'Unknown',
+  );
+
+  @override
+  void initState() {
+    super.initState();
+
+    _initPackageInfo();
+  }
+
+  Future<void> _initPackageInfo() async {
+    final PackageInfo info = await PackageInfo.fromPlatform();
+    setState(() {
+      _packageInfo = info;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Color(0xFF3D9098),
+        title: Text('About'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceAround,
+          children: <Widget>[
+            Column(
+              children: <Widget>[
+                Text('Empty Fridge', style: TextStyle(fontSize: 24.0, fontWeight: FontWeight.bold)),
+                Text('v. ${_packageInfo.version}', style: TextStyle(fontSize: 18.0)),
+            ]),
+            Text('Made by Dmitry Z and Andrew H', style: TextStyle(fontSize: 18.0)),
+          ],
+        ),
+      )
+    );
+  }
+}

--- a/lib/presentation/productSelection/screens/ProductSelectionScreen.dart
+++ b/lib/presentation/productSelection/screens/ProductSelectionScreen.dart
@@ -3,6 +3,7 @@ import 'package:empty_fridge/components/RoundedButton.dart';
 import 'package:empty_fridge/entities/Product.dart';
 import 'package:empty_fridge/presentation/productSelection/bloc/ProductSelection.dart';
 import 'package:empty_fridge/presentation/productSelection/bloc/ProductSelectionAction.dart';
+import 'package:empty_fridge/presentation/productSelection/screens/AboutScreen.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -36,9 +37,14 @@ class _ProductSelectionScreenState extends State<ProductSelectionScreen> {
                           child: IconButton(
                             icon: Icon(Icons.info_outline),
                             tooltip: 'Info',
-                            onPressed: () {},
+                            onPressed: () {
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(builder: (context) => AboutScreen()),
+                              );
+                            },
                           ),
-                        )
+                        ),
                       ],
                     ),
                     Consumer<ProductSelectionBloc>(builder: (context, _productSelectionBloc, child) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -107,6 +107,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.0.4"
+  package_info:
+    dependency: "direct main"
+    description:
+      name: package_info
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.0+16"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
 
   shared_preferences: ^0.5.6
 
+  package_info: ^0.4.0+16
 
 
 dev_dependencies:


### PR DESCRIPTION
Added the About screen.

I tried to make it as close to the mockup as possible.

The version is loaded dynamically, the name is nailed.

Tested only on iOS!
---
![Screenshot](https://user-images.githubusercontent.com/13130096/77100809-ad328d80-6a2f-11ea-86ba-cad9347e08e7.png)